### PR TITLE
Change dummy payload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "passfd"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Alexander Polakov <plhk@sdf.org>"]
 edition = "2018"
 description = "File descriptor passing"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,17 +56,17 @@ pub mod tokio_10;
 pub trait FdPassingExt {
     /// Send RawFd. No type information is transmitted.
     fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
-        let mut dummy_payload = [0u8; mem::size_of::<c_int>()];
-        self.send_fd_with_payload(fd, &mut dummy_payload[..])
+        let dummy_payload = [0u8; mem::size_of::<c_int>()];
+        self.send_fd_with_payload(fd, &dummy_payload[..])
     }
     /// Send RawFd. With custom payload to be nice to some receivers.
-    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error>;
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &[u8]) -> Result<(), Error>;
     /// Receive RawFd. No type information is transmitted.
     fn recv_fd(&self) -> Result<RawFd, Error>;
 }
 
 impl FdPassingExt for UnixStream {
-    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error> {
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &[u8]) -> Result<(), Error> {
         self.as_raw_fd().send_fd_with_payload(fd, payload)
     }
 
@@ -87,12 +87,12 @@ union HeaderAlignedBuf {
 }
 
 impl FdPassingExt for RawFd {
-    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error> {
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &[u8]) -> Result<(), Error> {
         let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
         let mut u = HeaderAlignedBuf { buf: [0; 256] };
         let mut iov = libc::iovec {
-            iov_base: payload.as_mut_ptr().cast(),
-            iov_len: mem::size_of_val(payload),
+            iov_base: payload.as_ptr() as *mut u8 as *mut c_void,
+            iov_len: payload.len(),
         };
 
         let mut msg: MaybeUninit<msghdr> = MaybeUninit::zeroed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,17 +56,17 @@ pub mod tokio_10;
 pub trait FdPassingExt {
     /// Send RawFd. No type information is transmitted.
     fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
-        let dummy_payload: c_int = 0;
-        self.send_fd_with_payload(fd, dummy_payload)
+        let mut dummy_payload = [0u8; mem::size_of::<c_int>()];
+        self.send_fd_with_payload(fd, &mut dummy_payload[..])
     }
     /// Send RawFd. With custom payload to be nice to some receivers.
-    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, payload: T) -> Result<(), Error>;
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error>;
     /// Receive RawFd. No type information is transmitted.
     fn recv_fd(&self) -> Result<RawFd, Error>;
 }
 
 impl FdPassingExt for UnixStream {
-    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, payload: T) -> Result<(), Error> {
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error> {
         self.as_raw_fd().send_fd_with_payload(fd, payload)
     }
 
@@ -87,12 +87,12 @@ union HeaderAlignedBuf {
 }
 
 impl FdPassingExt for RawFd {
-    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, mut payload: T) -> Result<(), Error> {
+    fn send_fd_with_payload(&self, fd: RawFd, payload: &mut [u8]) -> Result<(), Error> {
         let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
         let mut u = HeaderAlignedBuf { buf: [0; 256] };
         let mut iov = libc::iovec {
-            iov_base: &mut payload as *mut T as *mut c_void,
-            iov_len: mem::size_of_val(&payload),
+            iov_base: payload.as_mut_ptr().cast(),
+            iov_len: mem::size_of_val(payload),
         };
 
         let mut msg: MaybeUninit<msghdr> = MaybeUninit::zeroed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,14 +55,19 @@ pub mod tokio_10;
 /// Main trait, extends UnixStream
 pub trait FdPassingExt {
     /// Send RawFd. No type information is transmitted.
-    fn send_fd(&self, fd: RawFd) -> Result<(), Error>;
+    fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
+        let dummy_payload: c_int = 0;
+        self.send_fd_with_payload(fd, dummy_payload)
+    }
+    /// Send RawFd. With custom payload to be nice to some receivers.
+    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, payload: T) -> Result<(), Error>;
     /// Receive RawFd. No type information is transmitted.
     fn recv_fd(&self) -> Result<RawFd, Error>;
 }
 
 impl FdPassingExt for UnixStream {
-    fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
-        self.as_raw_fd().send_fd(fd)
+    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, payload: T) -> Result<(), Error> {
+        self.as_raw_fd().send_fd_with_payload(fd, payload)
     }
 
     fn recv_fd(&self) -> Result<RawFd, Error> {
@@ -82,13 +87,12 @@ union HeaderAlignedBuf {
 }
 
 impl FdPassingExt for RawFd {
-    fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
-        let mut dummy: c_int = 0;
+    fn send_fd_with_payload<T: Sized>(&self, fd: RawFd, mut payload: T) -> Result<(), Error> {
         let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
         let mut u = HeaderAlignedBuf { buf: [0; 256] };
         let mut iov = libc::iovec {
-            iov_base: &mut dummy as *mut c_int as *mut c_void,
-            iov_len: mem::size_of_val(&dummy),
+            iov_base: &mut payload as *mut T as *mut c_void,
+            iov_len: mem::size_of_val(&payload),
         };
 
         let mut msg: MaybeUninit<msghdr> = MaybeUninit::zeroed();


### PR DESCRIPTION
When talking to ssh control master, file descriptor can be sent.
However, on the [OpenSSH side](https://github.com/openssh/openssh-portable/blob/22efb01e355bba4755b730ed417f91c081445bfc/monitor_fdpass.c#L156), `recvmsg`  is expected to return exactly the value one.

In order not to change the API nor the default behavior, the trait `FdPassingExt` has been modified to include a new function `send_fd_with_payload`. The  `send_fd` function now has default implementation which uses `send_fd_with_payload` with a dummy  payload being a `c_int`.