### PR TITLE
Fix len check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,15 +158,10 @@ impl FdPassingExt for RawFd {
                 0 => Err(Error::new(ErrorKind::UnexpectedEof, "0 bytes read")),
                 rv if rv < 0 => Err(Error::last_os_error()),
                 _ => {
-                    let hdr: *mut libc::cmsghdr =
-                        if msg.msg_controllen >= mem::size_of::<libc::cmsghdr>() as _ {
-                            msg.msg_control as *mut libc::cmsghdr
-                        } else {
-                            return Err(Error::new(
-                                ErrorKind::InvalidData,
-                                "bad control msg (header)",
-                            ));
-                        };
+                    let hdr = libc::CMSG_FIRSTHDR(&msg);
+                    if hdr.is_null() {
+                        return Err(Error::new(ErrorKind::InvalidData, "missing control msg"));
+                    }
                     if (*hdr).cmsg_level != libc::SOL_SOCKET || (*hdr).cmsg_type != libc::SCM_RIGHTS
                     {
                         return Err(Error::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@ impl FdPassingExt for RawFd {
                 0 => Err(Error::new(ErrorKind::UnexpectedEof, "0 bytes read")),
                 rv if rv < 0 => Err(Error::last_os_error()),
                 _ => {
+                    if (msg.msg_flags & libc::MSG_CTRUNC) != 0 {
+                        return Err(Error::new(ErrorKind::InvalidData, "control data truncated"));
+                    };
                     let hdr = libc::CMSG_FIRSTHDR(&msg);
                     if hdr.is_null() {
                         return Err(Error::new(ErrorKind::InvalidData, "missing control msg"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,15 +165,11 @@ impl FdPassingExt for RawFd {
                     if hdr.is_null() {
                         return Err(Error::new(ErrorKind::InvalidData, "missing control msg"));
                     }
-                    if (*hdr).cmsg_level != libc::SOL_SOCKET || (*hdr).cmsg_type != libc::SCM_RIGHTS
+                    if (*hdr).cmsg_len != libc::CMSG_LEN(mem::size_of::<c_int>() as u32)
+                        || (*hdr).cmsg_level != libc::SOL_SOCKET
+                        || (*hdr).cmsg_type != libc::SCM_RIGHTS
                     {
-                        return Err(Error::new(
-                            ErrorKind::InvalidData,
-                            "bad control msg (level)",
-                        ));
-                    }
-                    if msg.msg_controllen != libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ {
-                        return Err(Error::new(ErrorKind::InvalidData, "bad control msg (len)"));
+                        return Err(Error::new(ErrorKind::InvalidData, "bad control msg"));
                     }
                     // https://github.com/rust-lang/rust-clippy/issues/2881
                     #[allow(clippy::cast_ptr_alignment)]


### PR DESCRIPTION
The main change is the last commit which exchanges the `msg_controllen` check for checking `cmsg_len`. On OpenBSD `msg_controllen` changes between what is sent in `sendmsg` and what is received in `recvmsg`.

With these changes the code more closely matches the recvmsg example at https://man.openbsd.org/CMSG_DATA#EXAMPLES .