### PR TITLE
Don't read data from the recv buffer when we're just interested in fd's

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl FdPassingExt for RawFd {
         let mut msg = unsafe { msg.assume_init() };
 
         unsafe {
-            let rv = libc::recvmsg(*self, &mut msg, 0);
+            let rv = libc::recvmsg(*self, &mut msg, libc::MSG_PEEK);
             match rv {
                 0 => Err(Error::new(ErrorKind::UnexpectedEof, "0 bytes read")),
                 rv if rv < 0 => Err(Error::last_os_error()),


### PR DESCRIPTION
This PR just sets the MSG_PEEK flag so we're not actually reading data from the recv buffer. I was wondering why the first 4 bytes of the message I was waiting for just disappeared.